### PR TITLE
Expliciting the ActionScript Developers Guide

### DIFF
--- a/learn/index.md
+++ b/learn/index.md
@@ -5,6 +5,11 @@ title: Learn
 
 # Learn
 
+## Fundamentals
+OpenFL is a port of ActionScript 3 for the Haxe programming language.
+This means that OpenFL mirrors ActionScript's classes and behaviours.
+So, for a better understanding of how things work, you can rely on <a href="http://help.adobe.com/en_US/as3/dev/index.html" target="_blank">ActionScript 3.0 Developer’s Guide</a>.
+
 ## Documentation
 
 For documentation on the classes available in Lime and OpenFL, please visit <a href="http://docs.openfl.org" target="_blank">docs.openfl.org</a>.
@@ -46,7 +51,7 @@ For documentation on the classes available in Lime and OpenFL, please visit <a h
  * <span class="glyphicon glyphicon-new-window"></span> <a href="http://haxecoder.com/post.php?id=45" target="_blank">HaxeFlixel RPG Tutorial</a>
 
 #### HaxePunk
- 
+
  * <span class="glyphicon glyphicon-new-window"></span> <a href="http://haxecoder.com/post.php?id=31" target="_blank">HaxePunk Tutorial: Getting Started</a>
  * <span class="glyphicon glyphicon-new-window"></span> <a href="http://haxecoder.com/post.php?id=32" target="_blank">HaxePunk Shooting Game Tutorial</a>
 


### PR DESCRIPTION
TL;DR - This commit adds a link to ActionScript Developers Guide inside the Learn section of the side.

Hello all o/
I'm totaly new to Haxe and OpenFL.
It's being almost 2 weeks since I decided to play with it.
The Learn section links to really cool tutorials, which was helpful.
But, as a developer, I always kept asking myself "why?" and "how?".
It turns out that, since I never used ActionScript before, I'd never be able to understand the key concepts, behaviours and functionalities of OpenFL.
Based on that, I thought it should be a good idea to, at least, link to the AS3DevGuide, so other n00bs (like me) can understand what's going on.

Thanks for everybody efforts!

PS: IMHO we should create a task force to rewrite (or copy-paste) the AS3DevGuide into a cool new OpenFL Developer Guide