### PR TITLE
Add iOS link for Run 3.

### DIFF
--- a/_data/showcase.yml
+++ b/_data/showcase.yml
@@ -79,6 +79,14 @@
   android: https://play.google.com/store/apps/details?id=com.kongregate.mobile.cardinalquest.google
   featured: true
 
+- title: Run 3
+  developer: player_03
+  image: Run3.jpg
+  url: http://www.kongregate.com/games/player_03/run-3
+  flash: http://www.kongregate.com/games/player_03/run-3
+  ios: https://itunes.apple.com/app/run!!!/id907239855
+  android: https://play.google.com/store/apps/details?id=com.kongregate.mobile.run.google
+
 - title: Werewolf Tycoon
   developer: Joe Williamson
   image: WerewolfTycoon.png
@@ -284,14 +292,6 @@
   url: http://mybogame.com/m/
   ios: http://itunes.apple.com/us/app/ponon-deluxe/id402642577
   android: https://play.google.com/store/apps/details?id=com.mybogame.ponon
-
-- title: Run 3
-  developer: player_03
-  image: Run3.jpg
-  url: http://www.kongregate.com/games/player_03/run-3
-  flash: http://www.kongregate.com/games/player_03/run-3
-  ios: https://itunes.apple.com/app/run!!!/id907239855
-  android: https://play.google.com/store/apps/details?id=com.kongregate.mobile.run.google
 
 - title: Letter Rush
   developer: Proletariat

--- a/_data/showcase.yml
+++ b/_data/showcase.yml
@@ -290,6 +290,7 @@
   image: Run3.jpg
   url: http://www.kongregate.com/games/player_03/run-3
   flash: http://www.kongregate.com/games/player_03/run-3
+  ios: https://itunes.apple.com/app/run!!!/id907239855
   android: https://play.google.com/store/apps/details?id=com.kongregate.mobile.run.google
 
 - title: Letter Rush


### PR DESCRIPTION
I also moved it up the page. I get that we're supposed to be modest about our own games, but there's no reason for a game with 10 million installs to be that far down.