### PR TITLE
Link to haxe.org/download.

### DIFF
--- a/download.md
+++ b/download.md
@@ -45,12 +45,7 @@ npm start
 	</div>
 	<div class="col-md-6 nopadding">
 		<h2>Haxelib <small><i>(Option 2)</i></small></h2>
-		<p>OpenFL is also available on haxelib, supporting HTML5, native desktop, mobile, AIR and Flash development from a single toolset and the Haxe programming language. To get started, install Haxe globally on your system:</p>
-		<ul>
-			<li><a href="https://github.com/HaxeFoundation/haxe/releases/download/4.0.5/haxe-4.0.5-win64.exe">Windows</a></li>
-			<li><a href="https://github.com/HaxeFoundation/haxe/releases/download/4.0.5/haxe-4.0.5-osx-installer.pkg">macOS</a></li>
-			<li><a href="https://haxe.org/download/linux/" target="_blank">Linux</a></li>
-		</ul>
+		<p>OpenFL is also available on haxelib, supporting HTML5, native desktop, mobile, AIR and Flash development from a single toolset and the Haxe programming language. To get started, <a href="https://haxe.org/download/" target="_blank">install Haxe globally on your system</a>.</p>
 		<p>With the latest versions of Haxe and Neko installed, open a command-prompt (Windows) or terminal (macOS/Linux) and run these commands:</p>
 {% highlight bash %}
 haxelib install openfl


### PR DESCRIPTION
The Haxe download links haven't been updated since [this two-year-old forum post](https://community.openfl.org/t/haxe-4-support/12414). I figure if users have to prompt us to update them, it isn't worth trying to keep them updated ourselves. Linking to haxe.org means the user will always get the latest version, not to mention extra download options and more detailed instructions.